### PR TITLE
Add `Array::try_from_iter`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ rust-version = "1.65"
 [dependencies]
 typenum = "1.17"
 zeroize = { version = "1.7", optional = true }
+
+[features]
+std = []

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,103 @@
+//! Support for constructing arrays using a provided iterator function and other iterator-related
+//! functionality.
+
+use crate::{Array, ArraySize};
+use core::{
+    fmt,
+    slice::{Iter, IterMut},
+};
+
+/// Couldn't construct an array from an iterator because the number of items in the iterator
+/// didn't match the array size.
+#[derive(Clone, Copy, Debug)]
+pub struct TryFromIteratorError;
+
+impl fmt::Display for TryFromIteratorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("iterator did not contain the correct number of items for the array size")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryFromIteratorError {}
+
+impl<T, U> Array<T, U>
+where
+    U: ArraySize,
+{
+    /// Construct an array from the given iterator, returning [`TryFromIteratorError`] in the event
+    /// that the number of items in the iterator does not match the array size.
+    pub fn try_from_iter<I: IntoIterator<Item = T>>(iter: I) -> Result<Self, TryFromIteratorError> {
+        let mut iter = iter.into_iter();
+        let ret = Self::try_from_fn(|_| iter.next().ok_or(TryFromIteratorError))?;
+
+        match iter.next() {
+            None => Ok(ret),
+            Some(_) => Err(TryFromIteratorError),
+        }
+    }
+}
+
+impl<T, U> FromIterator<T> for Array<T, U>
+where
+    U: ArraySize,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
+        let ret = Self::from_fn(|_| {
+            iter.next()
+                .expect("iterator should have enough items to fill array")
+        });
+
+        assert!(
+            iter.next().is_none(),
+            "too many items in iterator to fit in array"
+        );
+
+        ret
+    }
+}
+
+impl<T, U> IntoIterator for Array<T, U>
+where
+    U: ArraySize,
+{
+    type Item = T;
+    type IntoIter = <U::ArrayType<T> as IntoIterator>::IntoIter;
+
+    /// Creates a consuming iterator, that is, one that moves each value out of the array (from
+    /// start to end).
+    ///
+    /// The array cannot be used after calling this unless `T` implements `Copy`, so the whole
+    /// array is copied.
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T, U> IntoIterator for &'a Array<T, U>
+where
+    U: ArraySize,
+{
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+impl<'a, T, U> IntoIterator for &'a mut Array<T, U>
+where
+    U: ArraySize,
+{
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> IterMut<'a, T> {
+        self.iter_mut()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -23,7 +23,11 @@
     unused_qualifications
 )]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 mod from_fn;
+mod iter;
 mod sizes;
 
 pub use crate::from_fn::FromFn;
@@ -432,25 +436,6 @@ where
     }
 }
 
-impl<T, U> FromIterator<T> for Array<T, U>
-where
-    U: ArraySize,
-{
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut iter = iter.into_iter();
-        let ret = Self::from_fn(|_| {
-            iter.next()
-                .expect("iterator should have enough items to fill array")
-        });
-
-        assert!(
-            iter.next().is_none(),
-            "too many items in iterator to fit in array"
-        );
-        ret
-    }
-}
-
 impl<T, U> Hash for Array<T, U>
 where
     T: Hash,
@@ -483,48 +468,6 @@ where
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         IndexMut::index_mut(self.as_mut_slice(), index)
-    }
-}
-
-impl<T, U> IntoIterator for Array<T, U>
-where
-    U: ArraySize,
-{
-    type Item = T;
-    type IntoIter = <U::ArrayType<T> as IntoIterator>::IntoIter;
-
-    /// Creates a consuming iterator, that is, one that moves each value out of
-    /// the array (from start to end). The array cannot be used after calling
-    /// this unless `T` implements `Copy`, so the whole array is copied.
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<'a, T, U> IntoIterator for &'a Array<T, U>
-where
-    U: ArraySize,
-{
-    type Item = &'a T;
-    type IntoIter = Iter<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Iter<'a, T> {
-        self.iter()
-    }
-}
-
-impl<'a, T, U> IntoIterator for &'a mut Array<T, U>
-where
-    U: ArraySize,
-{
-    type Item = &'a mut T;
-    type IntoIter = IterMut<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> IterMut<'a, T> {
-        self.iter_mut()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod from_fn;
 mod iter;
 mod sizes;
 
-pub use crate::from_fn::FromFn;
+pub use crate::{from_fn::FromFn, iter::TryFromIteratorError};
 pub use typenum;
 pub use typenum::consts;
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -108,3 +108,21 @@ fn from_iterator_too_short() {
 fn from_iterator_too_long() {
     let _array: Array<u8, U5> = EXAMPLE_SLICE.iter().copied().collect();
 }
+
+#[test]
+fn try_from_iterator_correct_size() {
+    let array = Array::<u8, U6>::try_from_iter(EXAMPLE_SLICE.iter().copied()).unwrap();
+    assert_eq!(array.as_slice(), EXAMPLE_SLICE);
+}
+
+#[test]
+fn try_from_iterator_too_short() {
+    let result = Array::<u8, U7>::try_from_iter(EXAMPLE_SLICE.iter().copied());
+    assert!(result.is_err());
+}
+
+#[test]
+fn try_from_iterator_too_long() {
+    let result = Array::<u8, U5>::try_from_iter(EXAMPLE_SLICE.iter().copied());
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Adds a fallible equivalent to `FromIterator` which returns `TryFromIteratorError` if the number of items in the iterator does not match the size of the array.