### PR TITLE
Remove doc link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Hybrid array type combining const generics with the expressiveness of
 [`typenum`]-based constraints, providing an alternative to [`generic-array`]
 and a incremental transition path to const generics.
 
-[Documentation][docs-link]
-
 ## About
 
 This crate uses `typenum` to enable the following features which aren't yet


### PR DESCRIPTION
We use readme as crate docs, so it gets displayed for example when docs are [viewed](https://docs.rs/hybrid-array/0.2.0-rc.0/hybrid_array/) on docs.rs. I think it's quite redundant and the badge should be sufficient as a quick way to get to crate docs.