### PR TITLE
Add helper functions for `Array<MaybeUninit<T>, U>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,10 @@ where
     /// Create an uninitialized array of [`MaybeUninit`]s for the given type.
     pub const fn uninit() -> Self {
         // SAFETY: an array of `MaybeUninit`s is always valid.
-        unsafe { MaybeUninit::uninit().assume_init() }
+        #[allow(clippy::uninit_assumed_init)]
+        unsafe {
+            MaybeUninit::uninit().assume_init()
+        }
     }
 
     /// Extract the values from an array of `MaybeUninit` containers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,13 @@ where
 {
     /// Create an uninitialized array of [`MaybeUninit`]s for the given type.
     pub const fn uninit() -> Self {
-        // SAFETY: an array of `MaybeUninit`s is always valid.
+        // SAFETY: `Self` is a `repr(transparent)` newtype for `[MaybeUninit<T>; N]`. It is safe
+        // to assume `[MaybeUninit<T>; N]` is "initialized" because there is no initialization state
+        // for a `MaybeUninit`: it's a type for representing potentially uninitialized memory (and
+        // in this case it's uninitialized).
+        //
+        // See how `core` defines `MaybeUninit::uninit_array` for a similar example:
+        // <https://github.com/rust-lang/rust/blob/917f654/library/core/src/mem/maybe_uninit.rs#L350-L352>
         #[allow(clippy::uninit_assumed_init)]
         unsafe {
             MaybeUninit::uninit().assume_init()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,28 @@ where
     }
 }
 
+impl<T, U> Array<MaybeUninit<T>, U>
+where
+    U: ArraySize,
+{
+    /// Create an uninitialized array of [`MaybeUninit`]s for the given type.
+    pub const fn uninit() -> Self {
+        // SAFETY: an array of `MaybeUninit`s is always valid.
+        unsafe { MaybeUninit::uninit().assume_init() }
+    }
+
+    /// Extract the values from an array of `MaybeUninit` containers.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee that all elements of the array are in an initialized
+    /// state.
+    pub unsafe fn assume_init(self) -> Array<T, U> {
+        // TODO(tarcieri): use `MaybeUninit::array_assume_init` when stable
+        ptr::read(self.as_ptr().cast())
+    }
+}
+
 impl<T, U> AsRef<[T]> for Array<T, U>
 where
     U: ArraySize,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,5 @@
 use hybrid_array::{Array, ArrayN};
+use std::mem::MaybeUninit;
 use typenum::{U0, U2, U3, U4, U5, U6, U7};
 
 const EXAMPLE_SLICE: &[u8] = &[1, 2, 3, 4, 5, 6];
@@ -125,4 +126,16 @@ fn try_from_iterator_too_short() {
 fn try_from_iterator_too_long() {
     let result = Array::<u8, U5>::try_from_iter(EXAMPLE_SLICE.iter().copied());
     assert!(result.is_err());
+}
+
+#[test]
+fn maybe_uninit() {
+    let mut uninit_array = Array::<MaybeUninit<u8>, U6>::uninit();
+
+    for i in 0..6 {
+        uninit_array[i].write(EXAMPLE_SLICE[i]);
+    }
+
+    let array = unsafe { uninit_array.assume_init() };
+    assert_eq!(array.as_slice(), EXAMPLE_SLICE);
 }


### PR DESCRIPTION
Adds the following functions:

- `uninit`: construct an uninitialized `Array<MaybeUninit<T>, U>`
- `assume_init`: converts to `Array<T, U>` assuming all elements are initialized