### PR TITLE
Add `Send` and `Sync` impls for `Array`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,14 @@ where
     }
 }
 
+/// SAFETY: `Array` is a `repr(transparent)` newtype for `[T; N]`, so as long as `T: Send` it should
+/// also be `Send`.
+unsafe impl<T, U: ArraySize> Send for Array<T, U> where T: Send {}
+
+/// SAFETY: `Array` is a `repr(transparent)` newtype for `[T; N]`, so as long as `T: Sync` it should
+/// also be `Sync`.
+unsafe impl<T, U: ArraySize> Sync for Array<T, U> where T: Sync {}
+
 impl<'a, T, U> TryFrom<&'a [T]> for Array<T, U>
 where
     Self: Clone,


### PR DESCRIPTION
Impls `Send` if the underlying type `T: Send`, and likewise for `T: Sync`.

Closes #14.