### PR TITLE
Rename `ArrayOps::ref_mut_from_core_array`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,7 @@ where
 {
     #[inline]
     fn as_mut(&mut self) -> &mut Array<T, U> {
-        Array::ref_from_mut_core_array(self)
+        Array::ref_mut_from_core_array(self)
     }
 }
 
@@ -466,7 +466,7 @@ where
 {
     #[inline]
     fn from(array_ref: &'a mut [T; N]) -> &'a mut Array<T, U> {
-        <Array<T, U>>::ref_from_mut_core_array(array_ref)
+        <Array<T, U>>::ref_mut_from_core_array(array_ref)
     }
 }
 

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -38,7 +38,7 @@ macro_rules! impl_array_size {
                 }
 
                 #[inline]
-                fn ref_from_mut_core_array(array_ref: &mut [T; $len]) -> &mut Self {
+                fn ref_mut_from_core_array(array_ref: &mut [T; $len]) -> &mut Self {
                     // SAFETY: `Self` is a `repr(transparent)` newtype for `[T; $len]`
                     unsafe { &mut *array_ref.as_mut_ptr().cast() }
                 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -69,7 +69,7 @@ pub trait ArrayOps<T, const N: usize>:
     fn ref_from_core_array(arr: &[T; N]) -> &Self;
 
     /// Create mutable array reference from reference to Rust's core array type.
-    fn ref_from_mut_core_array(arr: &mut [T; N]) -> &mut Self;
+    fn ref_mut_from_core_array(arr: &mut [T; N]) -> &mut Self;
 
     /// Returns an array of the same size as `self`, with function `f` applied to each element
     /// in order.
@@ -114,7 +114,7 @@ impl<T, const N: usize> ArrayOps<T, N> for [T; N] {
     }
 
     #[inline]
-    fn ref_from_mut_core_array(array_ref: &mut [T; N]) -> &mut Self {
+    fn ref_mut_from_core_array(array_ref: &mut [T; N]) -> &mut Self {
         array_ref
     }
 


### PR DESCRIPTION
Renames the method from the original `ref_from_mut_core_array`.

I just tried to guess what we called this and couldn't, which is probably a sign it's a bad name.

We use `ref_mut` elsewhere, e.g. `split_ref_mut`, and it nicely follows `deref_mut` from core as well.

Though this is a breaking change, we don't seem to use this method elsewhere in the project yet, AFAICT.