### PR TITLE
Add `ArrayOps::to_core_array`

### DIFF
--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -27,6 +27,11 @@ macro_rules! impl_array_size {
                 }
 
                 #[inline]
+                fn to_core_array(self) -> [T; $len] {
+                    self.0
+                }
+
+                #[inline]
                 fn from_core_array(arr: [T; $len]) -> Self {
                     Self(arr)
                 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -62,6 +62,9 @@ pub trait ArrayOps<T, const N: usize>:
     /// Returns a mutable reference to the inner array.
     fn as_mut_core_array(&mut self) -> &mut [T; N];
 
+    /// Create Rust's core array type from array.
+    fn to_core_array(self) -> [T; N];
+
     /// Create array from Rust's core array type.
     fn from_core_array(arr: [T; N]) -> Self;
 
@@ -100,6 +103,11 @@ impl<T, const N: usize> ArrayOps<T, N> for [T; N] {
 
     #[inline]
     fn as_mut_core_array(&mut self) -> &mut [T; N] {
+        self
+    }
+
+    #[inline]
+    fn to_core_array(self) -> [T; N] {
         self
     }
 


### PR DESCRIPTION
This adds `ArrayOps::to_core_array` to parallel `ArrayOps::from_core_array` and `ArrayOps::as_core_array`.

I'm using `sha1` for working with git internals and wanted to convert `GenericArray` to `[u8; 20]`. The latest version of `generic-array`, v1.0.0 added [`GenericArray::into_array`](https://fizyk20.github.io/generic-array/generic_array/struct.GenericArray.html#method.into_array), which is exactly what I want; however, the current published version of `crypto-common` uses `generic-array` v0.14.7. I was going to open an issue there, but found the issues regarding the migration now to `hybrid-array` and eventually to const generic arrays, so I'm contributing this here instead.

I debated calling it `into_core_array` to match Rust convention, but followed local convention.