### PR TITLE
Remove `ArrayOps::from_core_array`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,9 @@ where
 {
     #[inline]
     fn from(arr: [T; N]) -> Array<T, U> {
-        Self::from_core_array(arr)
+        // SAFETY: `Array` is a `repr(transparent)` newtype for `[T; N]` when it impls
+        // `ArrayOps<T, N>`.
+        unsafe { ptr::read(arr.as_ptr().cast()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use core::{
     cmp::Ordering,
     fmt::{self, Debug},
     hash::{Hash, Hasher},
+    mem,
     mem::{ManuallyDrop, MaybeUninit},
     ops::{Add, Deref, DerefMut, Index, IndexMut, Sub},
     ptr,
@@ -424,7 +425,11 @@ where
     fn from(arr: [T; N]) -> Array<T, U> {
         // SAFETY: `Array` is a `repr(transparent)` newtype for `[T; N]` when it impls
         // `ArrayOps<T, N>`.
-        unsafe { ptr::read(arr.as_ptr().cast()) }
+        unsafe {
+            let ptr = arr.as_ptr();
+            mem::forget(arr);
+            ptr::read(ptr.cast())
+        }
     }
 }
 

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -27,11 +27,6 @@ macro_rules! impl_array_size {
                 }
 
                 #[inline]
-                fn from_core_array(arr: [T; $len]) -> Self {
-                    Self(arr)
-                }
-
-                #[inline]
                 fn ref_from_core_array(array_ref: &[T; $len]) -> &Self {
                     // SAFETY: `Self` is a `repr(transparent)` newtype for `[T; $len]`
                     unsafe { &*array_ref.as_ptr().cast() }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -62,9 +62,6 @@ pub trait ArrayOps<T, const N: usize>:
     /// Returns a mutable reference to the inner array.
     fn as_mut_core_array(&mut self) -> &mut [T; N];
 
-    /// Create array from Rust's core array type.
-    fn from_core_array(arr: [T; N]) -> Self;
-
     /// Create array reference from reference to Rust's core array type.
     fn ref_from_core_array(arr: &[T; N]) -> &Self;
 
@@ -101,11 +98,6 @@ impl<T, const N: usize> ArrayOps<T, N> for [T; N] {
     #[inline]
     fn as_mut_core_array(&mut self) -> &mut [T; N] {
         self
-    }
-
-    #[inline]
-    fn from_core_array(arr: [T; N]) -> Self {
-        arr
     }
 
     #[inline]


### PR DESCRIPTION
We can use a pointer cast instead.

This is a holdover from when `hybrid-array` was implemented without any unsafe code, but since we're using `unsafe` elsewhere to do the same thing, this simplifies things.