### PR TITLE
Safe conversions between `Array` and `[T; N]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,20 +417,16 @@ where
 
 impl<T, U, const N: usize> From<[T; N]> for Array<T, U>
 where
-    Self: ArrayOps<T, N>,
-    U: ArraySize,
+    U: ArraySize<ArrayType<T> = [T; N]>,
 {
     #[inline]
     fn from(arr: [T; N]) -> Array<T, U> {
-        // SAFETY: `Array` is a `repr(transparent)` newtype for `[T; N]` when it impls
-        // `ArrayOps<T, N>`.
-        unsafe { ptr::read(ManuallyDrop::new(arr).as_ptr().cast()) }
+        Array(arr)
     }
 }
 
 impl<T, U, const N: usize> From<Array<T, U>> for [T; N]
 where
-    Array<T, U>: ArrayOps<T, N>,
     U: ArraySize<ArrayType<T> = [T; N]>,
 {
     #[inline]


### PR DESCRIPTION
Simply bounding on `ArrayType<T> = [T; N]` is enough to accomplish this.

I've verified this change against a few of our repos (e.g. `block-ciphers`, `elliptic-curve`) and it does not seem to cause any inference problems.

When this bound is in place there's no need for `ArrayOps<T, N>` either.