### PR TITLE
Remove `FromFn` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ mod iter;
 mod sizes;
 mod traits;
 
-pub use crate::{from_fn::FromFn, iter::TryFromIteratorError, traits::*};
+pub use crate::{iter::TryFromIteratorError, traits::*};
 pub use typenum;
 pub use typenum::consts;
 
@@ -165,27 +165,6 @@ impl<T, U> Array<T, U>
 where
     U: ArraySize,
 {
-    /// Create array where each array element `T` is returned by the `cb` call.
-    pub fn from_fn<F>(cb: F) -> Self
-    where
-        F: FnMut(usize) -> T,
-    {
-        Self(FromFn::from_fn(cb))
-    }
-
-    /// Create array fallibly where each array element `T` is returned by the `cb` call, or return
-    /// an error if any are encountered.
-    ///
-    /// # Errors
-    ///
-    /// Propagates the `E` type returned from the provided `F` in the event of error.
-    pub fn try_from_fn<E, F>(f: F) -> Result<Self, E>
-    where
-        F: FnMut(usize) -> Result<T, E>,
-    {
-        FromFn::try_from_fn(f).map(Self)
-    }
-
     /// Returns an iterator over the array.
     #[inline]
     pub fn iter(&self) -> Iter<'_, T> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 //! Trait definitions.
 
-use crate::{Array, FromFn};
+use crate::Array;
 use core::{
     borrow::{Borrow, BorrowMut},
     ops::{Index, IndexMut, Range},
@@ -28,7 +28,6 @@ pub unsafe trait ArraySize: Unsigned {
         + Borrow<[T]>
         + BorrowMut<[T]>
         + From<Array<T, Self>>
-        + FromFn<T>
         + Index<usize>
         + Index<Range<usize>>
         + IndexMut<usize>


### PR DESCRIPTION
This trait was a sort of crutch to thunk to constructing the inner array type, but isn't strictly necessary and just adds implementation complexity.

Instead, we can have `try_from_fn` use the `AsMut` bound on the inner type to provide access to the inner array, and compose `Array::from_fn` in terms of `Array::try_from_fn`.

The result is less complexity and API surface, without subtracting any functionality.