### PR TITLE
Remove `ArrayType<MaybeUninit<T>> = [MaybeUninit<T>; N]` bounds

### DIFF
--- a/src/from_fn.rs
+++ b/src/from_fn.rs
@@ -24,16 +24,11 @@ where
     ///
     /// Propagates the `E` type returned from the provided `F` in the event of error.
     pub fn try_from_fn<E>(f: impl FnMut(usize) -> Result<T, E>) -> Result<Self, E> {
-        // SAFETY: `Array` is a `repr(transparent)` newtype for `[MaybeUninit<T>; N]`, i.e. an
-        // array of uninitialized memory mediated via the `MaybeUninit` interface, which is
-        // always valid.
-        #[allow(clippy::uninit_assumed_init)]
-        let mut array: Array<MaybeUninit<T>, U> = unsafe { MaybeUninit::uninit().assume_init() };
+        let mut array = Array::<MaybeUninit<T>, U>::uninit();
         try_from_fn_erased(array.0.as_mut(), f)?;
 
-        // TODO(tarcieri): use `MaybeUninit::array_assume_init` when stable
         // SAFETY: if we got here, every element of the array was initialized
-        Ok(unsafe { ptr::read(array.as_ptr().cast()) })
+        Ok(unsafe { array.assume_init() })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,8 @@ where
     /// Create an uninitialized array of [`MaybeUninit`]s for the given type.
     pub const fn uninit() -> Array<MaybeUninit<T>, U> {
         // SAFETY: `Array` is a `repr(transparent)` newtype for `[MaybeUninit<T>, N]`, i.e. an
-        // array of uninitialized memory mediated via the `MaybeUninit` interface.
+        // array of uninitialized memory mediated via the `MaybeUninit` interface, where the inner
+        // type is constrained by `ArraySize` impls which can only be added by this crate.
         //
         // Calling `uninit().assume_init()` triggers the `clippy::uninit_assumed_init` lint, but
         // as just mentioned the inner type we're "assuming init" for is `[MaybeUninit<T>, N]`,
@@ -395,6 +396,17 @@ where
     /// state.
     #[inline]
     pub unsafe fn assume_init(self) -> Array<T, U> {
+        // `Array` is a `repr(transparent)` newtype for a generic inner type which is constrained to
+        // be `[T; N]` by the `ArraySize` impls in this crate.
+        //
+        // Since we're working with a type-erased inner type and ultimately trying to convert
+        // `[MaybeUninit<T>; N]` to `[T; N]`, we can't use simpler approaches like a pointer cast
+        // or `transmute`, since the compiler can't prove to itself that the size will be the same.
+        //
+        // We've taken unique ownership of `self`, which is a `MaybeUninit` array, and as such we
+        // don't need to worry about `Drop` impls because `MaybeUninit` does not impl `Drop`.
+        // Since we have unique ownership of `self`, it's okay to make a copy because we're throwing
+        // the original away (and this should all get optimized to a noop by the compiler, anyway).
         mem::transmute_copy(&self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,7 @@ where
     ///
     /// It is up to the caller to guarantee that all elements of the array are in an initialized
     /// state.
+    #[inline]
     pub unsafe fn assume_init(self) -> Array<T, U> {
         mem::transmute_copy(&self)
     }


### PR DESCRIPTION
This makes it possible to call `Array::uninit` from `Array::try_from_fn` without propagating this bound, both to that function and everything else that calls it, including `try_from_iter` and the `FromIterator` trait impl.

This bound can be useful in places where we need access to `N`, but in the specific cae of `Array::uninit` it's effectively an implementation detail which, when provided, made clippy happy, because it could see the inner type was a `MaybeUninit` array.

The safety comments spell out the rationale for why this is sound, which effectively boils down to "uninitialized memory requires no initialization".

The downside is that the previous implementation was quite close to the equivalent code in `core`/`std` and this deviates considerably.