### PR TITLE
Enable `typenum`'s `const-generics` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-typenum = "1.17"
+typenum = { version = "1.17", features = ["const-generics"] }
 zeroize = { version = "1.7", optional = true }
 
 [features]


### PR DESCRIPTION
Though this doesn't immediately leverage the feature, it could potentially be useful in implementing e.g. `ArrayN` or as a replacement for `AssociatedArraySize`.

Enabling the feature does make it accessible for downstream users as `hybrid_array::typenum`.