### PR TITLE
Rename `AssociatedArraySize` => `AssocArraySize`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ use typenum::{Diff, Sum};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Type alias for [`Array`] which is const generic around a size `N`, ala `[T; N]`.
-pub type ArrayN<T, const N: usize> = Array<T, <[T; N] as AssociatedArraySize>::Size>;
+pub type ArrayN<T, const N: usize> = Array<T, <[T; N] as AssocArraySize>::Size>;
 
 /// [`Array`] is a newtype for an inner `[T; N]` array where `N` is determined by a generic
 /// [`ArraySize`] parameter, which is a marker trait for a numeric value determined by ZSTs that
@@ -134,7 +134,7 @@ pub type ArrayN<T, const N: usize> = Array<T, <[T; N] as AssociatedArraySize>::S
 /// The [`AsRef`] trait can be used to convert from `&Array<T, U>` to `&[T; N]` and vice versa:
 ///
 /// ```
-/// use hybrid_array::{Array, ArraySize, AssociatedArraySize, ArrayN, consts::U3};
+/// use hybrid_array::{Array, ArraySize, AssocArraySize, ArrayN, consts::U3};
 ///
 /// pub fn get_third_item_hybrid_array<T, U: ArraySize>(arr_ref: &Array<T, U>) -> &T {
 ///     &arr_ref[2]
@@ -142,7 +142,7 @@ pub type ArrayN<T, const N: usize> = Array<T, <[T; N] as AssociatedArraySize>::S
 ///
 /// pub fn get_third_item_const_generic<T, const N: usize>(arr_ref: &[T; N]) -> &T
 /// where
-///     [T; N]: AssociatedArraySize + AsRef<ArrayN<T, N>>
+///     [T; N]: AssocArraySize + AsRef<ArrayN<T, N>>
 /// {
 ///     get_third_item_hybrid_array(arr_ref.as_ref())
 /// }
@@ -150,9 +150,9 @@ pub type ArrayN<T, const N: usize> = Array<T, <[T; N] as AssociatedArraySize>::S
 /// assert_eq!(get_third_item_const_generic(&[1u8, 2, 3, 4]), &3);
 /// ```
 ///
-/// Note that the [`AssociatedArraySize`] trait can be used to determine the appropriate
+/// Note that the [`AssocArraySize`] trait can be used to determine the appropriate
 /// [`Array`] size for a given `[T; N]`, and the [`ArrayN`] trait (which internally uses
-/// [`AssociatedArraySize`]) can be used to determine the specific [`Array`] type for a given
+/// [`AssocArraySize`]) can be used to determine the specific [`Array`] type for a given
 /// const generic size.
 #[repr(transparent)]
 pub struct Array<T, U: ArraySize>(pub U::ArrayType<T>);

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -1,6 +1,6 @@
 //! Macros for defining various array sizes, and their associated invocations.
 
-use super::{ArraySize, AssociatedArraySize};
+use super::{ArraySize, AssocArraySize};
 
 macro_rules! impl_array_size {
     ($($len:expr => $ty:ident),+) => {
@@ -9,7 +9,7 @@ macro_rules! impl_array_size {
                 type ArrayType<T> = [T; $len];
             }
 
-            impl<T> AssociatedArraySize for [T; $len] {
+            impl<T> AssocArraySize for [T; $len] {
                 type Size = typenum::$ty;
             }
         )+

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,7 +22,7 @@ pub unsafe trait ArraySize: Unsigned {
     ///
     /// This is always defined to be `[T; N]` where `N` is the same as
     /// [`ArraySize::USIZE`][`typenum::Unsigned::USIZE`].
-    type ArrayType<T>: AssociatedArraySize<Size = Self>
+    type ArrayType<T>: AssocArraySize<Size = Self>
         + AsRef<[T]>
         + AsMut<[T]>
         + Borrow<[T]>
@@ -37,12 +37,12 @@ pub unsafe trait ArraySize: Unsigned {
 }
 
 /// Associates an [`ArraySize`] with a given type.
-pub trait AssociatedArraySize: Sized {
+pub trait AssocArraySize: Sized {
     /// Size of an array type, expressed as a [`typenum`]-based [`ArraySize`].
     type Size: ArraySize;
 }
 
-impl<T, U> AssociatedArraySize for Array<T, U>
+impl<T, U> AssocArraySize for Array<T, U>
 where
     U: ArraySize,
 {


### PR DESCRIPTION
The new name is still long, but at least a little bit shorter