### PR TITLE
Feature gate `extra-sizes`

### DIFF
--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -37,6 +37,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --target ${{ matrix.target }} --features extra-sizes
 
   careful:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ zeroize = { version = "1.7", optional = true }
 
 [features]
 std = []
+extra-sizes = []

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -4,7 +4,7 @@
 //!
 //! - 0-256
 //! - 272-1024 (multiples of 16)
-//! - 1040-4096 (multiples of 32)
+//! - when the `extra-sizes` feature is enabled: 1040-4096 (multiples of 32)
 
 use super::{ArraySize, AssocArraySize};
 use typenum::consts::*;
@@ -342,6 +342,7 @@ impl_array_sizes! {
 /// Additional typenum size aliases beyond what are normally provided.
 ///
 /// These are defined using their component bits rather than `Add` to avoid conflicting impls.
+#[cfg(feature = "extra-sizes")]
 pub mod extra_sizes {
     use super::*;
     use typenum::{UInt, UTerm};


### PR DESCRIPTION
Allows more sizes to be added under `extra-sizes` without impacting baseline compile times (i.e. usable for most RustCrypto projects aside from post-quantum ones that require larger sizes)