### PR TITLE
Replace `consts` with `sizes`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,14 +87,21 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod sizes;
+
 mod from_fn;
 mod iter;
-mod sizes;
 mod traits;
+
+/// Legacy compatibility for `hybrid_array::consts`, which has been replaced by the [`sizes`]
+/// module instead.
+#[deprecated(since = "0.2.0", note = "use `sizes` instead")]
+pub mod consts {
+    pub use crate::sizes::*;
+}
 
 pub use crate::{iter::TryFromIteratorError, traits::*};
 pub use typenum;
-pub use typenum::consts;
 
 use core::{
     array::TryFromSliceError,


### PR DESCRIPTION
Replaces the re-export of `typenum::consts` by making the `sizes` module public.

This ensures that the `sizes` module only contains supported sizes with `ArraySize` impls which should help prevent confusion about which array sizes are supported.

It also makes the type aliases for `extra-sizes` available so they don't have to be computed.

Closes #64.