### PR TITLE
Disable `default-features` for `zeroize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 
 [dependencies]
 typenum = { version = "1.17", features = ["const-generics"] }
-zeroize = { version = "1.8", optional = true }
+zeroize = { version = "1.8", optional = true, default-features = false }
 
 [features]
 std = []


### PR DESCRIPTION
It was unintentionally linking liballoc