### PR TITLE
modify ArraySize to allow for arbitrary size support by third parties

### DIFF
--- a/src/from_fn.rs
+++ b/src/from_fn.rs
@@ -24,6 +24,7 @@ where
     ///
     /// Propagates the `E` type returned from the provided `F` in the event of error.
     pub fn try_from_fn<E>(f: impl FnMut(usize) -> Result<T, E>) -> Result<Self, E> {
+        core::convert::identity(U::__CHECK_INVARIANT);
         let mut array = Array::<MaybeUninit<T>, U>::uninit();
         try_from_fn_erased(array.0.as_mut(), f)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ use core::{
     ptr,
     slice::{self, Iter, IterMut},
 };
-use typenum::{Diff, Sum};
+use typenum::{Diff, Sum, Unsigned};
 
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -223,7 +223,7 @@ where
         unsafe {
             let array = ManuallyDrop::new(self);
             let head = ptr::read(array.as_ptr().cast());
-            let tail = ptr::read(array.as_ptr().add(N::USIZE).cast());
+            let tail = ptr::read(array.as_ptr().add(<N::Size as Unsigned>::USIZE).cast());
             (head, tail)
         }
     }
@@ -239,7 +239,7 @@ where
         unsafe {
             let array_ptr = self.as_ptr();
             let head = &*array_ptr.cast();
-            let tail = &*array_ptr.add(N::USIZE).cast();
+            let tail = &*array_ptr.add(<N::Size as Unsigned>::USIZE).cast();
             (head, tail)
         }
     }
@@ -255,7 +255,7 @@ where
         unsafe {
             let array_ptr = self.as_mut_ptr();
             let head = &mut *array_ptr.cast();
-            let tail = &mut *array_ptr.add(N::USIZE).cast();
+            let tail = &mut *array_ptr.add(<N::Size as Unsigned>::USIZE).cast();
             (head, tail)
         }
     }
@@ -268,12 +268,16 @@ where
     #[allow(clippy::arithmetic_side_effects)]
     #[inline]
     pub fn slice_as_chunks(buf: &[T]) -> (&[Self], &[T]) {
-        assert_ne!(U::USIZE, 0, "chunk size must be non-zero");
+        assert_ne!(
+            <U::Size as Unsigned>::USIZE,
+            0,
+            "chunk size must be non-zero"
+        );
         // Arithmetic safety: we have checked that `N::USIZE` is not zero, thus
         // division always returns correct result. `tail_pos` can not be bigger than `buf.len()`,
         // thus overflow on multiplication and underflow on substraction are impossible.
-        let chunks_len = buf.len() / U::USIZE;
-        let tail_pos = U::USIZE * chunks_len;
+        let chunks_len = buf.len() / <U::Size as Unsigned>::USIZE;
+        let tail_pos = <U::Size as Unsigned>::USIZE * chunks_len;
         let tail_len = buf.len() - tail_pos;
         unsafe {
             let ptr = buf.as_ptr();
@@ -291,12 +295,16 @@ where
     #[allow(clippy::arithmetic_side_effects)]
     #[inline]
     pub fn slice_as_chunks_mut(buf: &mut [T]) -> (&mut [Self], &mut [T]) {
-        assert_ne!(U::USIZE, 0, "chunk size must be non-zero");
+        assert_ne!(
+            <U::Size as Unsigned>::USIZE,
+            0,
+            "chunk size must be non-zero"
+        );
         // Arithmetic safety: we have checked that `N::USIZE` is not zero, thus
         // division always returns correct result. `tail_pos` can not be bigger than `buf.len()`,
         // thus overflow on multiplication and underflow on substraction are impossible.
-        let chunks_len = buf.len() / U::USIZE;
-        let tail_pos = U::USIZE * chunks_len;
+        let chunks_len = buf.len() / <U::Size as Unsigned>::USIZE;
+        let tail_pos = <U::Size as Unsigned>::USIZE * chunks_len;
         let tail_len = buf.len() - tail_pos;
         unsafe {
             let ptr = buf.as_mut_ptr();
@@ -825,9 +833,12 @@ where
 /// Generate a [`TryFromSliceError`] if the slice doesn't match the given length.
 #[cfg_attr(debug_assertions, allow(clippy::panic_in_result_fn))]
 fn check_slice_length<T, U: ArraySize>(slice: &[T]) -> Result<(), TryFromSliceError> {
-    debug_assert_eq!(Array::<(), U>::default().len(), U::USIZE);
+    debug_assert_eq!(
+        Array::<(), U>::default().len(),
+        <U::Size as Unsigned>::USIZE
+    );
 
-    if slice.len() != U::USIZE {
+    if slice.len() != <U::Size as Unsigned>::USIZE {
         // Hack: `TryFromSliceError` lacks a public constructor
         <&[T; 1]>::try_from([].as_slice())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,6 +613,7 @@ where
 {
     #[inline]
     fn from(arr: [T; N]) -> Array<T, U> {
+        core::convert::identity(U::__CHECK_INVARIANT);
         Array(arr)
     }
 }
@@ -774,6 +775,7 @@ where
 
     #[inline]
     fn try_from(slice: &'a [T]) -> Result<Array<T, U>, TryFromSliceError> {
+        core::convert::identity(U::__CHECK_INVARIANT);
         <&'a Self>::try_from(slice).map(Clone::clone)
     }
 }
@@ -786,6 +788,7 @@ where
 
     #[inline]
     fn try_from(slice: &'a [T]) -> Result<Self, TryFromSliceError> {
+        core::convert::identity(U::__CHECK_INVARIANT);
         check_slice_length::<T, U>(slice)?;
 
         // SAFETY: `Array<T, U>` is a `repr(transparent)` newtype for a core
@@ -802,6 +805,7 @@ where
 
     #[inline]
     fn try_from(slice: &'a mut [T]) -> Result<Self, TryFromSliceError> {
+        core::convert::identity(U::__CHECK_INVARIANT);
         check_slice_length::<T, U>(slice)?;
 
         // SAFETY: `Array<T, U>` is a `repr(transparent)` newtype for a core

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -22,6 +22,7 @@ macro_rules! impl_array_sizes {
     ($($len:expr => $ty:ident),+ $(,)?) => {
         $(
             unsafe impl ArraySize for $ty {
+                type Size = $ty;
                 type ArrayType<T> = [T; $len];
             }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,15 +13,15 @@ use typenum::Unsigned;
 /// # Safety
 ///
 /// `ArrayType` MUST be an array with a number of elements exactly equal to
-/// [`Size::USIZE`]. Breaking this requirement will cause undefined behavior.
+/// [`Self::Size::USIZE`]. Breaking this requirement will cause undefined behavior.
 pub unsafe trait ArraySize: Sized + 'static {
-    /// The size underlying
+    /// The size underlying the array.
     type Size: Unsigned;
 
     /// Array type which corresponds to this size.
     ///
     /// This is always defined to be `[T; N]` where `N` is the same as
-    /// [`ArraySize::USIZE`][`typenum::Unsigned::USIZE`].
+    /// [`ArraySize::Size::USIZE`][`typenum::Unsigned::USIZE`].
     type ArrayType<T>: AsRef<[T]>
         + AsMut<[T]>
         + Borrow<[T]>

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,17 +13,16 @@ use typenum::Unsigned;
 /// # Safety
 ///
 /// `ArrayType` MUST be an array with a number of elements exactly equal to
-/// [`Unsigned::USIZE`]. Breaking this requirement will cause undefined behavior.
-///
-/// NOTE: This trait is effectively sealed and can not be implemented by third-party crates.
-/// It is implemented only for a number of types defined in [`typenum::consts`].
-pub unsafe trait ArraySize: Unsigned {
+/// [`Size::USIZE`]. Breaking this requirement will cause undefined behavior.
+pub unsafe trait ArraySize: Sized + 'static {
+    /// The size underlying
+    type Size: Unsigned;
+
     /// Array type which corresponds to this size.
     ///
     /// This is always defined to be `[T; N]` where `N` is the same as
     /// [`ArraySize::USIZE`][`typenum::Unsigned::USIZE`].
-    type ArrayType<T>: AssocArraySize<Size = Self>
-        + AsRef<[T]>
+    type ArrayType<T>: AsRef<[T]>
         + AsMut<[T]>
         + Borrow<[T]>
         + BorrowMut<[T]>

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,6 +15,13 @@ use typenum::Unsigned;
 /// `ArrayType` MUST be an array with a number of elements exactly equal to
 /// [`Self::Size::USIZE`]. Breaking this requirement will cause undefined behavior.
 pub unsafe trait ArraySize: Sized + 'static {
+    #[doc(hidden)]
+    const __CHECK_INVARIANT: () = {
+        let a = <Self::Size as Unsigned>::USIZE;
+        let b = core::mem::size_of::<Self::ArrayType<u8>>();
+        assert!(a == b, "ArraySize invariant violated");
+    };
+
     /// The size underlying the array.
     type Size: Unsigned;
 

--- a/tests/custom_size.rs
+++ b/tests/custom_size.rs
@@ -1,74 +1,4 @@
-use std::{
-    borrow::{Borrow, BorrowMut},
-    ops::{Index, IndexMut, Range},
-};
-
 use hybrid_array::Array;
-
-struct CustomArray<T>([T; 54321]);
-impl<T> AsRef<[T]> for CustomArray<T> {
-    fn as_ref(&self) -> &[T] {
-        &self.0
-    }
-}
-impl<T> AsMut<[T]> for CustomArray<T> {
-    fn as_mut(&mut self) -> &mut [T] {
-        &mut self.0
-    }
-}
-impl<T> Borrow<[T]> for CustomArray<T> {
-    fn borrow(&self) -> &[T] {
-        &self.0
-    }
-}
-impl<T> BorrowMut<[T]> for CustomArray<T> {
-    fn borrow_mut(&mut self) -> &mut [T] {
-        &mut self.0
-    }
-}
-impl<T> From<Array<T, Size54321>> for CustomArray<T> {
-    fn from(value: Array<T, Size54321>) -> Self {
-        value.0
-    }
-}
-impl<T> From<CustomArray<T>> for Array<T, Size54321> {
-    fn from(val: CustomArray<T>) -> Self {
-        Array(val)
-    }
-}
-impl<T> IntoIterator for CustomArray<T> {
-    type Item = T;
-
-    type IntoIter = std::array::IntoIter<T, 54321>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-impl<T> Index<usize> for CustomArray<T> {
-    type Output = T;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
-    }
-}
-impl<T> IndexMut<usize> for CustomArray<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
-impl<T> Index<Range<usize>> for CustomArray<T> {
-    type Output = [T];
-
-    fn index(&self, index: Range<usize>) -> &Self::Output {
-        &self.0[index]
-    }
-}
-impl<T> IndexMut<Range<usize>> for CustomArray<T> {
-    fn index_mut(&mut self, index: Range<usize>) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
 
 struct Size54321;
 
@@ -83,7 +13,7 @@ macro_rules! uint {
 
 unsafe impl hybrid_array::ArraySize for Size54321 {
     type Size = uint!(1 0 0 0 1 1 0 0 0 0 1 0 1 0 1 1);
-    type ArrayType<T> = CustomArray<T>;
+    type ArrayType<T> = [T; 54321];
 }
 
 #[test]

--- a/tests/custom_size.rs
+++ b/tests/custom_size.rs
@@ -1,0 +1,93 @@
+use std::{
+    borrow::{Borrow, BorrowMut},
+    ops::{Index, IndexMut, Range},
+};
+
+use hybrid_array::Array;
+
+struct CustomArray<T>([T; 54321]);
+impl<T> AsRef<[T]> for CustomArray<T> {
+    fn as_ref(&self) -> &[T] {
+        &self.0
+    }
+}
+impl<T> AsMut<[T]> for CustomArray<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        &mut self.0
+    }
+}
+impl<T> Borrow<[T]> for CustomArray<T> {
+    fn borrow(&self) -> &[T] {
+        &self.0
+    }
+}
+impl<T> BorrowMut<[T]> for CustomArray<T> {
+    fn borrow_mut(&mut self) -> &mut [T] {
+        &mut self.0
+    }
+}
+impl<T> From<Array<T, Size54321>> for CustomArray<T> {
+    fn from(value: Array<T, Size54321>) -> Self {
+        value.0
+    }
+}
+impl<T> From<CustomArray<T>> for Array<T, Size54321> {
+    fn from(val: CustomArray<T>) -> Self {
+        Array(val)
+    }
+}
+impl<T> IntoIterator for CustomArray<T> {
+    type Item = T;
+
+    type IntoIter = std::array::IntoIter<T, 54321>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+impl<T> Index<usize> for CustomArray<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+impl<T> IndexMut<usize> for CustomArray<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+impl<T> Index<Range<usize>> for CustomArray<T> {
+    type Output = [T];
+
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        &self.0[index]
+    }
+}
+impl<T> IndexMut<Range<usize>> for CustomArray<T> {
+    fn index_mut(&mut self, index: Range<usize>) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
+struct Size54321;
+
+// This macro constructs a UInt type from a sequence of bits.  The bits are interpreted as the
+// little-endian representation of the integer in question.  For example, uint!(1 1 0 1 0 0 1) is
+// U75 (not U105).
+macro_rules! uint {
+    () => { typenum::UTerm };
+    (0 $($bs:tt)*) => { typenum::UInt< uint!($($bs)*), typenum::B0 > };
+    (1 $($bs:tt)*) => { typenum::UInt< uint!($($bs)*), typenum::B1 > };
+}
+
+unsafe impl hybrid_array::ArraySize for Size54321 {
+    type Size = uint!(1 0 0 0 1 1 0 0 0 0 1 0 1 0 1 1);
+    type ArrayType<T> = CustomArray<T>;
+}
+
+#[test]
+fn from_fn() {
+    let array = Array::<u8, Size54321>::from_fn(|n| (n + 1) as u8);
+    assert_eq!(array.as_slice().len(), 54321);
+}


### PR DESCRIPTION
I had this idea on discord to allow for third party crates to provide their own sizes. It means that `ArrayN<T, N>` no longer is guaranteed to always work, but it still unblocks users with odd sized arrays such that they can `unsafe impl` ArraySize themselves.

This also provides a best-effort invariant check that can catch wrong impls at compile time.

I appreciate if this design is undesirable, but I feel like #66 & #79 will be a never ending issue otherwise.