### PR TITLE
Remove std

### DIFF
--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: 1.81.0
           components: clippy
       - run: cargo clippy --all --all-features -- -D warnings
 
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.65.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ typenum = { version = "1.17", features = ["const-generics"] }
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [features]
-std = []
 extra-sizes = []
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["no-std", "data-structures"]
 keywords = ["generic-array"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.81.0"
 
 [dependencies]
 typenum = { version = "1.17", features = ["const-generics"] }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -18,8 +18,7 @@ impl fmt::Display for TryFromIteratorError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TryFromIteratorError {}
+impl core::error::Error for TryFromIteratorError {}
 
 impl<T, U> Array<T, U>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ where
         U: Add<N>,
         Sum<U, N>: ArraySize,
     {
-        self.into_iter().chain(other.into_iter()).collect()
+        self.into_iter().chain(other).collect()
     }
 
     /// Splits `self` at index `N` in two arrays.
@@ -763,7 +763,7 @@ where
 
     #[inline]
     fn try_from(slice: &'a [T]) -> Result<Array<T, U>, TryFromSliceError> {
-        <&'a Self>::try_from(slice).map(Clone::clone)
+        <&'a Self>::try_from(slice).cloned()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,9 +84,6 @@
 //! If you have any questions, please
 //! [start a discussion](https://github.com/RustCrypto/hybrid-array/discussions).
 
-#[cfg(feature = "std")]
-extern crate std;
-
 pub mod sizes;
 
 mod from_fn;


### PR DESCRIPTION
Changes to:
- Switch to `core::error::Error`
- Remove std feature
- Fixed two Clippy warnings

As requested in #74 

Changes do bump the MSRV to 1.81 as `core::error` was stabilized in this release.