### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Pending
+## 0.2.0 (2024-10-18)
+### Added
+- Reference conversion support from core arrays ([utils#904])
+- Impl `Default` for `Array` ([utils#905])
+- `Deref`/`DerefMut` impls for `Array` ([utils#908], [utils#913])
+- Impl `From<Array<T, U>>` for `[T; N]` ([utils#945])
+- Impl `IntoIterator` for all `ArraySize`s ([utils#956])
+- Impl `IntoIterator` for references to all `ArraySize`s ([utils#957])
+- Concat and split methods ([utils#958])
+- `slice_as_chunks(_mut)` methods ([utils#974])
+- Impl `Zeroize`/`ZeroizeOnDrop` for `Array` ([utils#984])
+- `AssocArraySize` trait ([utils#1006], [#40])
+- `sizes` submodule ([utils#1014], [#68])
+- `ArrayN` type alias ([utils#1017])
+- Impl `FromIterator` ([utils#1039])
+- `Array::try_from_iter` ([#4])
+- Helper functions for `Array<MaybeUninit<T>, U>` ([#8])
+- `Send` and `Sync` impls for `Array` ([#15])
+- `Array::map` ([#61])
+- Support all array sizes up to `U512` ([#67])
+- `Array<Array<...>>::as_flattened{_mut}()` ([#86])
+- `serde` support ([#88])
+- `bytemuck` support ([#99])
 
-* Implement `Zeroize` for `Array<T: Zeroize, U>`, and `ZeroizeOnDrop` for `Array<T: ZeroizeOnDrop, U>`
+### Changed
+- Use GATs for `ArraySize` ([utils#893])
+- Make `ArraySize` an `unsafe trait` ([utils#914])
+- MSRV 1.81 ([#85])
+
+### Removed
+- `ByteArray` type alias ([utils#995])
+- `ArrayOps` trait ([#30])
+- `std` feature ([#85])
+
+[utils#893]: https://github.com/RustCrypto/utils/pull/893
+[utils#904]: https://github.com/RustCrypto/utils/pull/904
+[utils#905]: https://github.com/RustCrypto/utils/pull/905
+[utils#908]: https://github.com/RustCrypto/utils/pull/908
+[utils#913]: https://github.com/RustCrypto/utils/pull/913
+[utils#914]: https://github.com/RustCrypto/utils/pull/914
+[utils#945]: https://github.com/RustCrypto/utils/pull/945
+[utils#956]: https://github.com/RustCrypto/utils/pull/956
+[utils#957]: https://github.com/RustCrypto/utils/pull/957
+[utils#958]: https://github.com/RustCrypto/utils/pull/958
+[utils#974]: https://github.com/RustCrypto/utils/pull/974
+[utils#984]: https://github.com/RustCrypto/utils/pull/984
+[utils#995]: https://github.com/RustCrypto/utils/pull/995
+[utils#1006]: https://github.com/RustCrypto/utils/pull/1006
+[utils#1014]: https://github.com/RustCrypto/utils/pull/1014
+[utils#1017]: https://github.com/RustCrypto/utils/pull/1017
+[utils#1039]: https://github.com/RustCrypto/utils/pull/1039
+[#4]: https://github.com/RustCrypto/hybrid-array/pull/4
+[#8]: https://github.com/RustCrypto/hybrid-array/pull/8
+[#15]: https://github.com/RustCrypto/hybrid-array/pull/15
+[#30]: https://github.com/RustCrypto/hybrid-array/pull/30
+[#40]: https://github.com/RustCrypto/hybrid-array/pull/40
+[#61]: https://github.com/RustCrypto/hybrid-array/pull/61
+[#67]: https://github.com/RustCrypto/hybrid-array/pull/67
+[#68]: https://github.com/RustCrypto/hybrid-array/pull/68
+[#85]: https://github.com/RustCrypto/hybrid-array/pull/85
+[#86]: https://github.com/RustCrypto/hybrid-array/pull/86
+[#88]: https://github.com/RustCrypto/hybrid-array/pull/88
+[#99]: https://github.com/RustCrypto/hybrid-array/pull/99
 
 ## 0.1.0 (2022-05-07)
 - Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.12"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.2.0-rc.12"
+version = "0.2.0"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/hybrid-array
+[crate-image]: https://img.shields.io/crates/v/hybrid-array?logo=rust
 [crate-link]: https://crates.io/crates/hybrid-array
 [docs-image]: https://docs.rs/hybrid-array/badge.svg
 [docs-link]: https://docs.rs/hybrid-array/


### PR DESCRIPTION
### Added
- Reference conversion support from core arrays ([utils#904])
- Impl `Default` for `Array` ([utils#905])
- `Deref`/`DerefMut` impls for `Array` ([utils#908], [utils#913])
- Impl `From<Array<T, U>>` for `[T; N]` ([utils#945])
- Impl `IntoIterator` for all `ArraySize`s ([utils#956])
- Impl `IntoIterator` for references to all `ArraySize`s ([utils#957])
- Concat and split methods ([utils#958])
- `slice_as_chunks(_mut)` methods ([utils#974])
- Impl `Zeroize`/`ZeroizeOnDrop` for `Array` ([utils#984])
- `AssocArraySize` trait ([utils#1006], [#40])
- `sizes` submodule ([utils#1014], [#68])
- `ArrayN` type alias ([utils#1017])
- Impl `FromIterator` ([utils#1039])
- `Array::try_from_iter` ([#4])
- Helper functions for `Array<MaybeUninit<T>, U>` ([#8])
- `Send` and `Sync` impls for `Array` ([#15])
- `Array::map` ([#61])
- Support all array sizes up to `U512` ([#67])
- `Array<Array<...>>::as_flattened{_mut}()` ([#86])
- `serde` support ([#88])
- `bytemuck` support ([#99])

### Changed
- Use GATs for `ArraySize` ([utils#893])
- Make `ArraySize` an `unsafe trait` ([utils#914])
- MSRV 1.81 ([#85])

### Removed
- `ByteArray` type alias ([utils#995])
- `ArrayOps` trait ([#30])
- `std` feature ([#85])

[utils#893]: https://github.com/RustCrypto/utils/pull/893
[utils#904]: https://github.com/RustCrypto/utils/pull/904
[utils#905]: https://github.com/RustCrypto/utils/pull/905
[utils#908]: https://github.com/RustCrypto/utils/pull/908
[utils#913]: https://github.com/RustCrypto/utils/pull/913
[utils#914]: https://github.com/RustCrypto/utils/pull/914
[utils#945]: https://github.com/RustCrypto/utils/pull/945
[utils#956]: https://github.com/RustCrypto/utils/pull/956
[utils#957]: https://github.com/RustCrypto/utils/pull/957
[utils#958]: https://github.com/RustCrypto/utils/pull/958
[utils#974]: https://github.com/RustCrypto/utils/pull/974
[utils#984]: https://github.com/RustCrypto/utils/pull/984
[utils#995]: https://github.com/RustCrypto/utils/pull/995
[utils#1006]: https://github.com/RustCrypto/utils/pull/1006
[utils#1014]: https://github.com/RustCrypto/utils/pull/1014
[utils#1017]: https://github.com/RustCrypto/utils/pull/1017
[utils#1039]: https://github.com/RustCrypto/utils/pull/1039
[#4]: https://github.com/RustCrypto/hybrid-array/pull/4
[#8]: https://github.com/RustCrypto/hybrid-array/pull/8
[#15]: https://github.com/RustCrypto/hybrid-array/pull/15
[#30]: https://github.com/RustCrypto/hybrid-array/pull/30
[#40]: https://github.com/RustCrypto/hybrid-array/pull/40
[#61]: https://github.com/RustCrypto/hybrid-array/pull/61
[#67]: https://github.com/RustCrypto/hybrid-array/pull/67
[#68]: https://github.com/RustCrypto/hybrid-array/pull/68
[#85]: https://github.com/RustCrypto/hybrid-array/pull/85
[#86]: https://github.com/RustCrypto/hybrid-array/pull/86
[#88]: https://github.com/RustCrypto/hybrid-array/pull/88
[#99]: https://github.com/RustCrypto/hybrid-array/pull/99