### PR TITLE
Optional `bytemuck` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+
+[[package]]
 name = "hybrid-array"
 version = "0.2.0-rc.11"
 dependencies = [
  "bincode",
+ "bytemuck",
  "serde",
  "typenum",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.81"
 typenum = { version = "1.17", features = ["const-generics"] }
 
 # optional dependencies
+bytemuck = { version = "1", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ possible with the stable implementation of const generics:
 Internally the crate is built on const generics and provides traits which make
 it possible to convert between const generic types and `typenum` types.
 
-## Features
-
-This crate exposes the following feature flags. The default is NO features.
-
-- `serde`: implements the `Deserialize` and `Serialize` traits for `Array`
-- `zeroize`: implements [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) for `Array<T: Zeroize, U>`
-
 ## License
 
 Licensed under either of:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,14 @@
     unused_qualifications
 )]
 
+//! ## Features
+//!
+//! This crate exposes the following feature flags. The default is NO features.
+//!
+//! - `bytemuck`: impls the `Pod` and `Zeroable` traits
+//! - `serde`: impls the `Deserialize` and `Serialize` traits for `Array`
+//! - `zeroize`: impls [`Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) for `Array<T: Zeroize, U>`
+//!
 //! ## Usage
 //!
 //! The two core types in this crate are as follows:
@@ -122,6 +130,9 @@ use core::{
     slice::{self, Iter, IterMut},
 };
 use typenum::{Diff, Sum};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -814,6 +825,23 @@ where
         // array with length checked above.
         Ok(unsafe { &mut *slice.as_mut_ptr().cast() })
     }
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, U> Pod for Array<T, U>
+where
+    T: Pod,
+    U: ArraySize,
+    U::ArrayType<T>: Copy,
+{
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, U> Zeroable for Array<T, U>
+where
+    T: Zeroable,
+    U: ArraySize,
+{
 }
 
 #[cfg(feature = "zeroize")]


### PR DESCRIPTION
Adds impls of `Pod` and `Zeroable` for `Array`s of types which impl these traits respectively.

Closes #83 