### PR TITLE
Update ML-DSA sizes

### DIFF
--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -809,7 +809,11 @@ mod extra_sizes {
     //
     // Includes the public key, private key, and signature sizes not covered elsewhere, as well as
     // some intermediate value sizes.
+    //
+    // U3293 is not required for ML-DSA, but was included in an early iteration of this section
+    // (before the `ml_dsa` crate was created).  So it is included here for backward compatibility.
     pub type U2420 = uint!(0 0 1 0 1 1 1 0 1 0 0 1);
+    pub type U3293 = uint!(1 0 1 1 1 0 1 1 0 0 1 1);
     pub type U3309 = uint!(1 0 1 1 0 1 1 1 0 0 1 1);
     pub type U4480 = uint!(0 0 0 0 0 0 0 1 1 0 0 0 1);
     pub type U4544 = uint!(0 0 0 0 0 0 1 1 1 0 0 0 1);
@@ -1057,6 +1061,7 @@ mod extra_sizes {
     // ML-DSA sizes
     impl_array_sizes! {
         2420 => U2420,
+        3293 => U3293,
         3309 => U3309,
         4480 => U4480,
         4544 => U4544,

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -806,9 +806,16 @@ mod extra_sizes {
     pub type U4080 = uint!(0 0 0 0 1 1 1 1 1 1 1 1);
 
     // ML-DSA sizes
+    //
+    // Includes the public key, private key, and signature sizes not covered elsewhere, as well as
+    // some intermediate value sizes.
     pub type U2420 = uint!(0 0 1 0 1 1 1 0 1 0 0 1);
-    pub type U3293 = uint!(1 0 1 1 1 0 1 1 0 0 1 1);
+    pub type U3309 = uint!(1 0 1 1 0 1 1 1 0 0 1 1);
+    pub type U4480 = uint!(0 0 0 0 0 0 0 1 1 0 0 0 1);
+    pub type U4544 = uint!(0 0 0 0 0 0 1 1 1 0 0 0 1);
     pub type U4595 = uint!(1 1 0 0 1 1 1 1 1 0 0 0 1);
+    pub type U4627 = uint!(1 1 0 0 1 0 0 0 0 1 0 0 1);
+    pub type U4896 = uint!(0 0 0 0 0 1 0 0 1 1 0 0 1);
 
     // SLH-DSA sizes
     pub type U7856 = uint!(0 0 0 0 1 1 0 1 0 1 1 1 1);
@@ -1050,8 +1057,12 @@ mod extra_sizes {
     // ML-DSA sizes
     impl_array_sizes! {
         2420 => U2420,
-        3293 => U3293,
+        3309 => U3309,
+        4480 => U4480,
+        4544 => U4544,
         4595 => U4595,
+        4627 => U4627,
+        4896 => U4896,
     }
 
     // SLH-DSA sizes


### PR DESCRIPTION
This PR was developed in parallel with https://github.com/RustCrypto/signatures/pull/877, to provide the array sizes necessary for serializing / deserializing ML-DSA keys and signatures.  In addition to the end key/signature sizes, some intermediate value sizes are required.  It would be OK with me to keep this open until the ML-DSA PR is closer to merging, in case any other required values pop up.  (I think it's unlikely at this point, since we're passing all the required tests.)  But this PR will need to merge and issue a new version before we can finalize the ML-DSA PR and have CI pass.