### PR TITLE
v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3 (2024-12-07)
+### Added
+- Additional ML-DSA sizes ([#108])
+
+[#108]: https://github.com/RustCrypto/hybrid-array/pull/108
+
 ## 0.2.2 (2024-11-11)
 ### Added
 - FrodoKEM sizes ([#104])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bincode",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.2.2"
+version = "0.2.3"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability


### PR DESCRIPTION
### Added
- Additional ML-DSA sizes ([#108])

[#108]: https://github.com/RustCrypto/hybrid-array/pull/108