### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2025-02-21)
+### Changed
+- Bump edition to 2024; MSRV 1.85 ([#116])
+
+### Removed
+- `U3293` as an unused ML-DSA size ([#117])
+
+[#116]: https://github.com/RustCrypto/hybrid-array/pull/116
+[#117]: https://github.com/RustCrypto/hybrid-array/pull/117
+
 ## 0.2.3 (2024-12-07)
 ### Added
 - Additional ML-DSA sizes ([#108])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "hybrid-array"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability


### PR DESCRIPTION
### Changed
- Bump edition to 2024; MSRV 1.85 ([#116])

### Removed
- `U3293` as an unused ML-DSA size ([#117])

[#116]: https://github.com/RustCrypto/hybrid-array/pull/116
[#117]: https://github.com/RustCrypto/hybrid-array/pull/117