### PR TITLE
`subtle` feature

### DIFF
--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -40,6 +40,7 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }} --features bytemuck
       - run: cargo build --no-default-features --target ${{ matrix.target }} --features extra-sizes
       - run: cargo build --no-default-features --target ${{ matrix.target }} --features serde
+      - run: cargo build --no-default-features --target ${{ matrix.target }} --features subtle
       - run: cargo build --no-default-features --target ${{ matrix.target }} --features zeroize
       - run: cargo build --no-default-features --target ${{ matrix.target }} --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "serde",
+ "subtle",
  "typenum",
  "zeroize",
 ]
@@ -76,6 +77,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ typenum = { version = "1.17", features = ["const-generics"] }
 # optional dependencies
 bytemuck = { version = "1", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
+subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/tests/subtle.rs
+++ b/tests/subtle.rs
@@ -1,0 +1,29 @@
+//! Tests for `subtle` crate integration.
+
+#![cfg(feature = "subtle")]
+
+use hybrid_array::{Array, typenum::U3};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+#[test]
+fn constant_time_eq() {
+    let a: Array<u8, U3> = Array([0, 0, 0]);
+    let b: Array<u8, U3> = Array([1, 2, 3]);
+
+    assert!(bool::from(a.ct_eq(&a)));
+    assert!(!bool::from(a.ct_ne(&a)));
+    assert!(!bool::from(a.ct_eq(&b)));
+    assert!(bool::from(a.ct_ne(&b)));
+}
+
+#[test]
+fn conditional_select() {
+    let a: Array<u8, U3> = Array([0, 0, 0]);
+    let b: Array<u8, U3> = Array([1, 2, 3]);
+
+    let c = Array::conditional_select(&a, &b, Choice::from(0));
+    assert_eq!(a, c);
+
+    let d = Array::conditional_select(&a, &b, Choice::from(1));
+    assert_eq!(b, d);
+}


### PR DESCRIPTION
Adds an off-by-default optional crate feature to support `subtle` traits including `ConstantTimeEq` and `ConditionallySelectable`.

Closes #125 