### PR TITLE
Remove `AsRef`/`AsMut` for `[T; N]` due to effects to all (even indirect) dependents

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,12 +466,12 @@ where
 }
 
 #[inline]
-fn array_ref_as_hybrid_array_ref<T, U, const N: usize>(array: &[T; N]) -> &Array<T, U>
+fn array_ref_as_hybrid_array_ref<T, U, const N: usize>(array_ref: &[T; N]) -> &Array<T, U>
 where
     U: ArraySize<ArrayType<T> = [T; N]>,
 {
     // SAFETY: `Self` is a `repr(transparent)` newtype for `[T; $len]`
-    unsafe { &*array.as_ptr().cast() }
+    unsafe { &*array_ref.as_ptr().cast() }
 }
 
 impl<T, U> AsMut<[T]> for Array<T, U>
@@ -494,15 +494,15 @@ where
     }
 }
 
-impl<T, U, const N: usize> AsMut<Array<T, U>> for [T; N]
+#[inline]
+fn array_mut_ref_as_hybrid_array_mut_ref<T, U, const N: usize>(
+    array_ref: &mut [T; N],
+) -> &mut Array<T, U>
 where
     U: ArraySize<ArrayType<T> = [T; N]>,
 {
-    #[inline]
-    fn as_mut(&mut self) -> &mut Array<T, U> {
-        // SAFETY: `Self` is a `repr(transparent)` newtype for `[T; $len]`
-        unsafe { &mut *self.as_mut_ptr().cast() }
-    }
+    // SAFETY: `Self` is a `repr(transparent)` newtype for `[T; $len]`
+    unsafe { &mut *array_ref.as_mut_ptr().cast() }
 }
 
 impl<T, U> Borrow<[T]> for Array<T, U>
@@ -660,7 +660,7 @@ where
 {
     #[inline]
     fn from(array_ref: &'a mut [T; N]) -> &'a mut Array<T, U> {
-        array_ref.as_mut()
+        array_mut_ref_as_hybrid_array_mut_ref(array_ref)
     }
 }
 


### PR DESCRIPTION
Resolves #131. I did maintain the `From<&[u8]>` references, which still offers a way to achieve the removed functionality (albeit not with the existing traits). I cannot comment this should be merged, solely lodge my issue and note this resolves my issue. I'll accept being told I'm the one who's misusing things and this is intended behavior :sweat_smile: 

This doesn't break `sha2 0.11.0-rc.0`, `blake2 0.11.0-rc.0` as used in my tree so hopefully it wouldn't actually be problematic to move forward with.