### PR TITLE
Remove `AsRef`/`AsMut` impls on `[T; N]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "hybrid-array"
-version = "0.3.1"
+version = "0.4.0-pre"
 dependencies = [
  "bincode",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.3.1"
+version = "0.4.0-pre"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability


### PR DESCRIPTION
Closes #131, #132

Notably these impls even existing can break code which would otherwise compile when `hybrid-array` is included as a dependency, due to some complex interactions between type inference and the sized-to-unsized coercion, something I previously knew little about prior to #131:

https://rustc-dev-guide.rust-lang.org/traits/unsize.html

Notably the existence of overlapping `AsRef` impls can break inference in cases where code is depending on the sized-to-unsized coercion, since the compiler can infer the desired type is `[T]` and coerce the other arguments from `[T; N]` into `[T]` to match.

When this is no longer possible, it can fail in some pretty counterintuitive ways. See #131 for examples.

This is all unfortunate because it's removing functionality which made it possible to expose `[T; N]` in public APIs so the caller didn't have to worry about `Array` at all. Perhaps we can lean on the `From` impls for doing such conversions instead.