### PR TITLE
Add `alloc` feature with `Box`/`Vec` conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ zeroize = { version = "1.8", optional = true, default-features = false }
 bincode = { version = "2", features = ["serde"] }
 
 [features]
+alloc = []
 extra-sizes = []
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,9 @@
 //! If you have any questions, please
 //! [start a discussion](https://github.com/RustCrypto/hybrid-array/discussions).
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod sizes;
 
 mod from_fn;
@@ -814,6 +817,62 @@ where
     #[inline]
     fn try_from(slice: &'a [T]) -> Result<Array<T, U>, TryFromSliceError> {
         <&'a Self>::try_from(slice).cloned()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> TryFrom<alloc::boxed::Box<[T]>> for Array<T, U>
+where
+    Self: Clone,
+    U: ArraySize,
+{
+    type Error = TryFromSliceError;
+
+    #[inline]
+    fn try_from(b: alloc::boxed::Box<[T]>) -> Result<Self, TryFromSliceError> {
+        Self::try_from(&*b)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T, U> TryFrom<&'a alloc::boxed::Box<[T]>> for Array<T, U>
+where
+    Self: Clone,
+    U: ArraySize,
+{
+    type Error = TryFromSliceError;
+
+    #[inline]
+    fn try_from(b: &'a alloc::boxed::Box<[T]>) -> Result<Self, TryFromSliceError> {
+        Self::try_from(&**b)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> TryFrom<alloc::vec::Vec<T>> for Array<T, U>
+where
+    Self: Clone,
+    U: ArraySize,
+{
+    type Error = TryFromSliceError;
+
+    #[inline]
+    fn try_from(v: alloc::vec::Vec<T>) -> Result<Self, TryFromSliceError> {
+        Self::try_from(v.as_slice())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, T, U> TryFrom<&'a alloc::vec::Vec<T>> for Array<T, U>
+where
+    Self: Clone,
+    U: ArraySize,
+{
+    type Error = TryFromSliceError;
+
+    #[inline]
+    fn try_from(v: &'a alloc::vec::Vec<T>) -> Result<Self, TryFromSliceError> {
+        Self::try_from(v.as_slice())
     }
 }
 


### PR DESCRIPTION
Adds `TryFrom` impls which convert from `Box`/`Vec`.

The main impetus for this is #114 where it's noted such conversions work for `[T; N]` but don't work for the `Array` type, where we are trying to make a type which works as much like core arrays as possible.

Closes #114