### PR TITLE
Add `From<Array>` conversions for `Box`/`Vec`

### DIFF
--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -37,6 +37,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --target ${{ matrix.target }} --features alloc
       - run: cargo build --no-default-features --target ${{ matrix.target }} --features bytemuck
       - run: cargo build --no-default-features --target ${{ matrix.target }} --features extra-sizes
       - run: cargo build --no-default-features --target ${{ matrix.target }} --features serde
@@ -110,6 +111,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo test
+      - run: cargo test --features alloc
       - run: cargo test --features bytemuck
       - run: cargo test --features extra-sizes
       - run: cargo test --features serde

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,7 +673,7 @@ where
 {
     #[inline]
     fn from(array: Array<T, U>) -> alloc::boxed::Box<[T]> {
-        alloc::vec::Vec::from(array).into_boxed_slice()
+        array.into_iter().collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,6 +666,52 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<T, U> From<Array<T, U>> for alloc::boxed::Box<[T]>
+where
+    U: ArraySize,
+{
+    #[inline]
+    fn from(array: Array<T, U>) -> alloc::boxed::Box<[T]> {
+        alloc::vec::Vec::from(array).into_boxed_slice()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> From<&Array<T, U>> for alloc::boxed::Box<[T]>
+where
+    T: Clone,
+    U: ArraySize,
+{
+    #[inline]
+    fn from(array: &Array<T, U>) -> alloc::boxed::Box<[T]> {
+        array.as_slice().into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> From<Array<T, U>> for alloc::vec::Vec<T>
+where
+    U: ArraySize,
+{
+    #[inline]
+    fn from(array: Array<T, U>) -> alloc::vec::Vec<T> {
+        array.into_iter().collect()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, U> From<&Array<T, U>> for alloc::vec::Vec<T>
+where
+    T: Clone,
+    U: ArraySize,
+{
+    #[inline]
+    fn from(array: &Array<T, U>) -> alloc::vec::Vec<T> {
+        array.as_slice().into()
+    }
+}
+
 impl<T, U> Hash for Array<T, U>
 where
     T: Hash,


### PR DESCRIPTION
Gated on the `alloc` feature, added in #136.

These are cooresponding changes which allow conversions the other way.

The owned conversion moves array elements into a `Box<[T]>` or `Vec<T>`.

The borrowed conversion bounds on `T: Clone` ala the upstream impls in liballoc.