### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2025-09-01)
+### Added
+- `ArraySize` impls for `U536` and `U568` ([#128])
+- `AsArrayRef`/`AsArrayMut` traits with impls on `[T; N]` and `Array` ([#135])
+- `alloc` feature with `Box`/`Vec` conversions to/from `Array` ([#136], [#138])
+
+### Removed
+- `AsRef`/`AsMut` impls on `[T; N]` ([#133])
+
+[#128]: https://github.com/RustCrypto/hybrid-array/pull/128
+[#133]: https://github.com/RustCrypto/hybrid-array/pull/133
+[#135]: https://github.com/RustCrypto/hybrid-array/pull/135
+[#136]: https://github.com/RustCrypto/hybrid-array/pull/136
+[#138]: https://github.com/RustCrypto/hybrid-array/pull/138
+
 ## 0.3.1 (2025-03-30)
 ### Added
 - `subtle` feature ([#126])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability


### PR DESCRIPTION
### Added
- `ArraySize` impls for `U536` and `U568` ([#128])
- `AsArrayRef`/`AsArrayMut` traits with impls on `[T; N]` and `Array` ([#135])
- `alloc` feature with `Box`/`Vec` conversions to/from `Array` ([#136], [#138])

### Removed
- `AsRef`/`AsMut` impls on `[T; N]` ([#133])

[#128]: https://github.com/RustCrypto/hybrid-array/pull/128
[#133]: https://github.com/RustCrypto/hybrid-array/pull/133
[#135]: https://github.com/RustCrypto/hybrid-array/pull/135
[#136]: https://github.com/RustCrypto/hybrid-array/pull/136
[#138]: https://github.com/RustCrypto/hybrid-array/pull/138