### PR TITLE
Remove bounds on `as_flattened(_mut)`; make `const fn`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,32 @@ where
         }
     }
 
+    /// Obtain a flattened slice from a slice of array chunks.
+    #[inline]
+    pub const fn slice_as_flattened(slice: &[Self]) -> &[T] {
+        let len = slice
+            .len()
+            .checked_mul(U::USIZE)
+            .expect("slice len overflow");
+
+        // SAFETY: `[T]` is layout-identical to `Array<T, U>`, which is a `repr(transparent)`
+        // newtype for `[T; N]`.
+        unsafe { slice::from_raw_parts(slice.as_ptr().cast(), len) }
+    }
+
+    /// Obtain a mutable flattened slice from a mutable slice of array chunks.
+    #[inline]
+    pub const fn slice_as_flattened_mut(slice: &mut [Self]) -> &mut [T] {
+        let len = slice
+            .len()
+            .checked_mul(U::USIZE)
+            .expect("slice len overflow");
+
+        // SAFETY: `[T]` is layout-identical to `Array<T, U>`, which is a `repr(transparent)`
+        // newtype for `[T; N]`.
+        unsafe { slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), len) }
+    }
+
     /// Convert the given slice into a reference to a hybrid array.
     ///
     /// # Panics
@@ -399,18 +425,6 @@ where
     pub const fn cast_slice_from_core_mut(slice: &mut [[T; N]]) -> &mut [Self] {
         // SAFETY: `Self` is a `repr(transparent)` newtype for `[T; N]`
         unsafe { slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len()) }
-    }
-
-    /// Obtain a flattened slice from a slice of array chunks.
-    #[inline]
-    pub fn slice_as_flattened(slice: &[Self]) -> &[T] {
-        Self::cast_slice_to_core(slice).as_flattened()
-    }
-
-    /// Obtain a mutable flattened slice from a mutable slice of array chunks.
-    #[inline]
-    pub fn slice_as_flattened_mut(slice: &mut [Self]) -> &mut [T] {
-        Self::cast_slice_to_core_mut(slice).as_flattened_mut()
     }
 }
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -144,3 +144,13 @@ fn clone_from_slice() {
     let array = Array::<u8, U6>::clone_from_slice(EXAMPLE_SLICE);
     assert_eq!(array.as_slice(), EXAMPLE_SLICE);
 }
+
+#[test]
+fn slice_as_flattened() {
+    let slice: &mut [Array<u8, U4>] = &mut [Array([1, 2, 3, 4]), Array([5, 6, 7, 8])];
+    assert_eq!(
+        Array::slice_as_flattened_mut(slice),
+        &mut [1, 2, 3, 4, 5, 6, 7, 8]
+    );
+    assert_eq!(Array::slice_as_flattened(slice), &[1, 2, 3, 4, 5, 6, 7, 8]);
+}


### PR DESCRIPTION
Also adds tests.

Previously these used the core `[T]::as_flattened(_mut)` to avoid additional unsafe code, however instead this approach opts to use a similar strategy to how the upstream `as_flattened(_mut)` is implemented to avoid having to have a bound on the inner `ArrayType`.