### PR TITLE
v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.2 (2025-09-21)
+## 0.4.3 (2025-09-23)
+### Added
+- `Array::as_(mut_)ptr` ([#147])
+
+### Changed
+- Remove bounds on `Array::slice_as_flattened(_mut)`; make `const fn` ([#144])
+- Make `Array::as_(mut_)slice` a `const fn` ([#147])
+- Make `Array::<Array<T, U>::as_flattened(_mut)` a `const fn` ([#147])
+
+[#144]: https://github.com/RustCrypto/hybrid-array/pull/144
+[#147]: https://github.com/RustCrypto/hybrid-array/pull/147
+
+## 0.4.2 (2025-09-21) [YANKED]
 ### Added
 - `Array::slice_as_flattened(_mut)` ([#142])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bincode",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.4.2"
+version = "0.4.3"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability


### PR DESCRIPTION
### Added
- `Array::as_(mut_)ptr` ([#147])

### Changed
- Remove bounds on `Array::slice_as_flattened(_mut)`; make `const fn` ([#144])
- Make `Array::as_(mut_)slice` a `const fn` ([#147])
- Make `Array::<Array<T, U>::as_flattened(_mut)` a `const fn` ([#147])

[#144]: https://github.com/RustCrypto/hybrid-array/pull/144
[#147]: https://github.com/RustCrypto/hybrid-array/pull/147