### PR TITLE
Enable the `subtle/const-generics` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ typenum = { version = "1.17", features = ["const-generics"] }
 # optional dependencies
 bytemuck = { version = "1", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
-subtle = { version = "2", optional = true, default-features = false }
+subtle = { version = "2", optional = true, default-features = false, features = ["const-generics"] }
 zeroize = { version = "1.8", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
`subtle` is an optional dependency, but when it's enabled, this also enables its `const-generics` feature