### PR TITLE
Impl `arbitrary::Arbitrary` for `Array`

### DIFF
--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -37,8 +37,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --optional-deps bytemuck,serde,subtle,zeroize
-      - run: cargo build --all-features --release
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-all-features --optional-deps bytemuck,serde,subtle,zeroize
 
   careful:
     runs-on: ubuntu-latest
@@ -106,5 +105,5 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --optional-deps bytemuck,serde,subtle,zeroize
+      - run: cargo hack test --feature-powerset --optional-deps arbitrary,bytemuck,serde,subtle,zeroize
       - run: cargo test --all-features --release

--- a/.github/workflows/hybrid-array.yml
+++ b/.github/workflows/hybrid-array.yml
@@ -105,5 +105,5 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --optional-deps arbitrary,bytemuck,serde,subtle,zeroize
+      - run: cargo hack test --feature-powerset --optional-deps arbitrary,bytemuck,serde,subtle,zeroize --group-features arbitrary,bytemuck,serde,subtle,zeroize
       - run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +38,7 @@ checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 name = "hybrid-array"
 version = "0.4.4"
 dependencies = [
+ "arbitrary",
  "bincode",
  "bytemuck",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.85"
 typenum = { version = "1.17", features = ["const-generics"] }
 
 # optional dependencies
+arbitrary = { version = "1", optional = true }
 bytemuck = { version = "1", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false, features = ["const-generics"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,9 @@ use core::{
 };
 use typenum::{Diff, Sum};
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, Zeroable};
 
@@ -1025,6 +1028,17 @@ where
         Self: Clone,
     {
         slice.try_into().expect("slice length mismatch")
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> Arbitrary<'a> for Array<T, U>
+where
+    T: Arbitrary<'a>,
+    U: ArraySize,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Self::try_from_fn(|_n| Arbitrary::arbitrary(u))
     }
 }
 


### PR DESCRIPTION
Support for creating arbitrary arrays using rust-fuzz's `arbitrary` crate, which is useful for randomized testing