### PR TITLE
v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.5 (2025-09-29)
+### Added
+- Impl `arbitrary::Arbitrary` for `Array` ([#153])
+
+### Changed
+- Switch from `doc_auto_cfg` to `doc_cfg` ([#154])
+
+[#153]: https://github.com/RustCrypto/hybrid-array/pull/153
+[#154]: https://github.com/RustCrypto/hybrid-array/pull/154
+
 ## 0.4.4 (2025-09-24)
 ### Added
 - Enable the `subtle/const-generics` feature ([#149])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.4.4"
+version = "0.4.5"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability


### PR DESCRIPTION
### Added
- Impl `arbitrary::Arbitrary` for `Array` ([#153])

### Changed
- Switch from `doc_auto_cfg` to `doc_cfg` ([#154])

[#153]: https://github.com/RustCrypto/hybrid-array/pull/153
[#154]: https://github.com/RustCrypto/hybrid-array/pull/154