### PR TITLE
Add tests for `TryFrom<&Box>` and `...&Vec>` for `Array`

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -491,10 +491,27 @@ mod allocating {
     }
 
     #[test]
+    fn array_try_from_boxed_slice_ref() {
+        type A = Array<u8, U2>;
+        assert!(A::try_from(&vec![1].into_boxed_slice()).is_err());
+        assert_eq!(
+            &A::try_from(&vec![1, 2].into_boxed_slice()).unwrap(),
+            &[1, 2]
+        );
+    }
+
+    #[test]
     fn array_try_from_vec() {
         type A = Array<u8, U2>;
         assert!(A::try_from(vec![1]).is_err());
         assert_eq!(&A::try_from(vec![1, 2]).unwrap(), &[1, 2]);
+    }
+
+    #[test]
+    fn array_try_from_vec_ref() {
+        type A = Array<u8, U2>;
+        assert!(A::try_from(&vec![1]).is_err());
+        assert_eq!(&A::try_from(&vec![1, 2]).unwrap(), &[1, 2]);
     }
 
     #[test]


### PR DESCRIPTION
These have a `Clone` bound and otherwise act like the `TryFrom` impl which converts from slices by cloning their contents