### PR TITLE
Add tests for `serde` impl's `Visitor::expected`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,26 +30,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 dependencies = [
  "arbitrary",
  "bytemuck",
  "ctutils",
- "postcard",
  "serde",
+ "serde_json",
  "subtle",
  "typenum",
  "zerocopy",
@@ -66,16 +45,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "postcard"
-version = "1.1.3"
+name = "itoa"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
-]
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "proc-macro2"
@@ -102,7 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -126,6 +104,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,26 +131,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -199,3 +170,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1.8", optional = true, default-features = false }
 zerocopy = { version = "0.8", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-postcard = { version = "1", default-features = false, features = ["alloc"] }
+serde_json = "1"
 
 [features]
 alloc = []

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -76,10 +76,18 @@ mod tests {
     type A = Array<u8, U3>;
 
     #[test]
+    #[cfg(feature = "alloc")]
+    fn expecting() {
+        use alloc::string::ToString;
+        let err = serde_json::from_str::<A>("true").unwrap_err();
+        assert!(err.to_string().contains("expected an array of length 3"));
+    }
+
+    #[test]
     fn round_trip() {
         let example: A = Array([1, 2, 3]);
-        let bytes = postcard::to_allocvec(&example).unwrap();
-        let deserialized: A = postcard::from_bytes(&bytes).unwrap();
+        let s = serde_json::to_string(&example).unwrap();
+        let deserialized: A = serde_json::from_str(&s).unwrap();
         assert_eq!(example, deserialized);
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -258,7 +258,7 @@ mod tests {
 
         let (slice_aligned, rem_aligned) = [1u8, 2].as_hybrid_chunks::<U2>();
         assert_eq!(slice_aligned, &[Array([1u8, 2])]);
-        assert_eq!(rem_aligned, &[]);
+        assert_eq!(rem_aligned, b"");
 
         let (slice_unaligned, rem_unaligned) = [1u8, 2, 3].as_hybrid_chunks::<U2>();
         assert_eq!(slice_unaligned, &[Array([1u8, 2])]);
@@ -279,7 +279,7 @@ mod tests {
         let mut arr2 = [1u8, 2];
         let (slice_aligned, rem_aligned) = arr2.as_hybrid_chunks_mut::<U2>();
         assert_eq!(slice_aligned, &mut [Array([1u8, 2])]);
-        assert_eq!(rem_aligned, &mut []);
+        assert_eq!(rem_aligned, b"");
 
         let mut arr3 = [1u8, 2, 3];
         let (slice_unaligned, rem_unaligned) = arr3.as_hybrid_chunks_mut::<U2>();


### PR DESCRIPTION
This is what is added to error messages when we're expecting an `Array` but some other type in a self-describing format is encountered instead.

To test this we need a self-describing format, so this uses `serde_json`, and replaces `postcard` with `serde_json` for the round trip test since we can't use `postcard` to test both.