### PR TITLE
.codecov.yml: bump coverage target to 100%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,5 @@
 coverage:
   status:
-    patch: off
     project:
       default:
-        target: 95%
+        target: 100%


### PR DESCRIPTION
We've gotten to 100%. Let's keep it that way.