### PR TITLE
v0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.12 (2026-05-09)
+### Added
+- `ArraySize` impls for Classic McEliece ([#220])
+
+[#220]: https://github.com/RustCrypto/hybrid-array/pull/220
+
 ## 0.4.11 (2026-04-24)
 ### Added
 - HPKE Hybrid KEM sizes ([#218])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "arbitrary",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 description = """
 Hybrid typenum-based and const generic array types designed to provide the
 flexibility of typenum-based expressions while also allowing interoperability


### PR DESCRIPTION
## Added
- `ArraySize` impls for Classic McEliece ([#220])

[#220]: https://github.com/RustCrypto/hybrid-array/pull/220